### PR TITLE
fix core dumped in hdspmixer.cxx

### DIFF
--- a/echomixer/echomixer.c
+++ b/echomixer/echomixer.c
@@ -19,6 +19,7 @@
 #define EM_VERSION "%s Echomixer v" VERSION
 
 
+
 /*******
   Remove the "//" if you want to compile Echomixer in reverse mode.
 *******/

--- a/hdspmixer/src/hdspmixer.cxx
+++ b/hdspmixer/src/hdspmixer.cxx
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 {
     HDSPMixerWindow *window;
     HDSPMixerCard *hdsp_cards[3];
-    char *name, *shortname;
+    char *name = NULL, *shortname;
     int card;
     int cards = 0;
 


### PR DESCRIPTION
because the pointer "name" is not assigned at first
when you use /usr/bin/hdspmixer like "/usr/bin/hdspmixer hello",the point name will be freed directly
and will appear:
free(): invalid pointer
Aborted (core dumped)

so we need to assign NULL to the pointer "name" at first to avoid the problem