### PR TITLE
Fix build failure on Clang 16

### DIFF
--- a/echomixer/echomixer.c
+++ b/echomixer/echomixer.c
@@ -2105,7 +2105,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     for (i=0; i<ndmodes; i++) {
       menuitem=gtk_menu_item_new_with_label(dmodeName[i]);
       gtk_widget_show(menuitem);
-      gtk_signal_connect(GTK_OBJECT(menuitem), "activate", Digital_mode_activate, (gpointer)(long)i);
+      gtk_signal_connect(GTK_OBJECT(menuitem), "activate", G_CALLBACK(Digital_mode_activate), (gpointer)(long)i);
       gtk_menu_append(GTK_MENU(menu), menuitem);
     }
     gtk_option_menu_set_menu(GTK_OPTION_MENU(dmodeOpt), menu);
@@ -2131,7 +2131,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
       clocksrc_menuitem[i]=gtk_menu_item_new_with_label(clocksrcName[i]);
       gtk_widget_show(clocksrc_menuitem[i]);
       gtk_widget_set_sensitive(clocksrc_menuitem[i], FALSE);
-      gtk_signal_connect(GTK_OBJECT(clocksrc_menuitem[i]), "activate", Clock_source_activate, (gpointer)(long)i);
+      gtk_signal_connect(GTK_OBJECT(clocksrc_menuitem[i]), "activate", G_CALLBACK(Clock_source_activate), (gpointer)(long)i);
       gtk_menu_append(GTK_MENU(menu), clocksrc_menuitem[i]);
     }
     gtk_option_menu_set_menu(GTK_OPTION_MENU(clocksrcOpt), menu);
@@ -2157,7 +2157,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     for (i=0; i<nspdifmodes; i++) {
       menuitem=gtk_menu_item_new_with_label(spdifmodeName[i]);
       gtk_widget_show(menuitem);
-      gtk_signal_connect(GTK_OBJECT(menuitem), "activate", SPDIF_mode_activate, (gpointer)(long)i);
+      gtk_signal_connect(GTK_OBJECT(menuitem), "activate", G_CALLBACK(SPDIF_mode_activate), (gpointer)(long)i);
       gtk_menu_append(GTK_MENU(menu), menuitem);
     }
     gtk_option_menu_set_menu(GTK_OPTION_MENU(spdifmodeOpt), menu);
@@ -2182,7 +2182,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
       gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, FALSE, 0);
       ReadControl(&i, 1, PhantomPower.id, SND_CTL_ELEM_IFACE_MIXER);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), i);
-      gtk_signal_connect(GTK_OBJECT(button), "toggled", Switch_toggled, (gpointer)&PhantomPower);
+      gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(Switch_toggled), (gpointer)&PhantomPower);
       PhantomPower.Button=button;
     }
 
@@ -2193,7 +2193,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
       gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, FALSE, 0);
       ReadControl(&i, 1, Automute.id, SND_CTL_ELEM_IFACE_CARD);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), i);
-      gtk_signal_connect(GTK_OBJECT(button), "toggled", Switch_toggled, (gpointer)&Automute);
+      gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(Switch_toggled), (gpointer)&Automute);
       Automute.Button=button;
     }
 
@@ -2202,7 +2202,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
       autoclockChkbutton=gtk_check_button_new_with_label("Autoclock");
       gtk_widget_show(autoclockChkbutton);
       gtk_box_pack_start(GTK_BOX(hbox), autoclockChkbutton, TRUE, FALSE, 0);
-      gtk_signal_connect(GTK_OBJECT(autoclockChkbutton), "toggled", AutoClock_toggled, NULL);
+      gtk_signal_connect(GTK_OBJECT(autoclockChkbutton), "toggled", G_CALLBACK(AutoClock_toggled), NULL);
       AutoClock=-1;
     }
   }
@@ -2672,7 +2672,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
   gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), 1);
   gtk_widget_show(button);
-  gtk_signal_connect(GTK_OBJECT(button), "toggled", Gang_button_toggled, 0);
+  gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(Gang_button_toggled), 0);
 
   // Controls frame
   frame=gtk_frame_new("Controls");
@@ -2687,7 +2687,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("VU");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", VUmeters_button_click, 0);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(VUmeters_button_click), 0);
     VUw_geom.toggler=button;
     if (VUw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2697,7 +2697,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
   button=gtk_toggle_button_new_with_label("Line");
   gtk_widget_show(button);
   gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-  gtk_signal_connect(GTK_OBJECT(button), "toggled", ToggleWindow, (gpointer)LVwindow);
+  gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(ToggleWindow), (gpointer)LVwindow);
   LVw_geom.toggler=button;
   if (LVw_geom.st==1)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2707,7 +2707,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("Misc");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", ToggleWindow, (gpointer)Miscwindow);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(ToggleWindow), (gpointer)Miscwindow);
     Miscw_geom.toggler=button;
     if (Miscw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2718,7 +2718,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("GrMix");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", GMixer_button_click, 0);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(GMixer_button_click), 0);
     GMw_geom.toggler=button;
     if (GMw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2727,7 +2727,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("Mixer");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", ToggleWindow, (gpointer)mixerControl.window);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(ToggleWindow), (gpointer)mixerControl.window);
     Mixerw_geom.toggler=button;
     if (Mixerw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2738,7 +2738,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("Vmixer");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", ToggleWindow, (gpointer)vmixerControl.window);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(ToggleWindow), (gpointer)vmixerControl.window);
     Vmixerw_geom.toggler=button;
     if (Vmixerw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -2749,7 +2749,7 @@ printf("components = %s\n", snd_ctl_card_info_get_components(hw_info));*/
     button=gtk_toggle_button_new_with_label("PCM");
     gtk_widget_show(button);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 1);
-    gtk_signal_connect(GTK_OBJECT(button), "toggled", ToggleWindow, (gpointer)pcmoutControl.window);
+    gtk_signal_connect(GTK_OBJECT(button), "toggled", G_CALLBACK(ToggleWindow), (gpointer)pcmoutControl.window);
     PVw_geom.toggler=button;
     if (PVw_geom.st==1)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);


### PR DESCRIPTION
Explicitly casting to `GCallback`, defined as `void (*)(void)`, through the `G_CALLBACK` function.

Fixes issue #12 and by extension https://bugs.gentoo.org/show_bug.cgi?id=880997.

cc @capezotte @thesamesam