### PR TITLE
Make (extern) declarations and definition of macro_depth consistent

### DIFF
--- a/as10k1/as10k1.h
+++ b/as10k1/as10k1.h
@@ -55,6 +55,6 @@ int tram_table_count=0;
 int gpr_constant_count=0;
 
 char patch_name[PATCH_NAME_SIZE]="NO_NAME";
-int macro_depth=0;
+unsigned int macro_depth=0;
 
 


### PR DESCRIPTION
All `extern` declarations refer to it as `unsigned int`, but the actual definition is a signed integer.

Reported by CBMC's goto-cc compiler, which performs type-aware linking.