### PR TITLE
envy24control: fix crash when using system profiles file

### DIFF
--- a/envy24control/profiles.c
+++ b/envy24control/profiles.c
@@ -78,7 +78,9 @@ int which_cfgfile(char ** const cfgfile)
 			   (inputFile = fopen(SYS_PROFILERC, "r")) == NULL) {
 			res = -ENOENT;
 		} else {
-			fclose(inputFile);
+			if (inputFile != NULL) {
+				fclose(inputFile);
+			}
 			*cfgfile = SYS_PROFILERC;
 			res = EXIT_SUCCESS;
 		}


### PR DESCRIPTION
envy24control crashed if you tried to start it with -f /etc/envy24control/profiles.conf.