### PR TITLE
envy24control: fix file descriptor leaks in profiles

### DIFF
--- a/envy24control/profiles.c
+++ b/envy24control/profiles.c
@@ -1144,13 +1144,16 @@ int save_restore(const char * const operation, const int profile_number, const i
 				fprintf(stderr, "Cannot save settings for card '%d' in profile '%d'.\n", card_number, profile_number);
 				return -errno;
 			}
+			close(res);
 			unlink(cfgfile);
 		} else {
+			close(res);
 			if ((res = open(cfgfile, O_RDWR | 0400000 /* O_NOFOLLOW */, FILE_CREA_MODE)) < 0) {
 				fprintf(stderr, "Cannot open configuration file '%s' for writing.\n", cfgfile);
 				fprintf(stderr, "Cannot save settings for card '%d' in profile '%d'.\n", card_number, profile_number);
 				return -errno;
 			}
+			close(res);
 		}
 		res =  save_profile(profile_number, card_number, profile_name, cfgfile);
 	} else if (!strcmp(operation, ALSACTL_OP_RESTORE)) {


### PR DESCRIPTION
File descriptors were leaked when "Save active profile" was pressed. Add the missing calls to close.