### PR TITLE
envy24control: update README

### DIFF
--- a/envy24control/README
+++ b/envy24control/README
@@ -1,11 +1,10 @@
 envy24control - Control tool for Envy24 (ice1712) based soundcards
 
 Needs:
-	ALSA, GTK+, an Envy24-based soundcard
+	ALSA, GTK4, an Envy24-based soundcard
 
 To build (from unpacked tarball):
 	./configure
-If you use GTK+-1.2, pass --with-gtk2=no
 
 	make
 	su -c 'make install'


### PR DESCRIPTION
A minor change to prevent downstream from mistakenly removing this GTK4-based package when dropping GTK2.